### PR TITLE
sc 154156/update node js server side sdk hello app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# hello-bootstrap
+# LaunchDarkly sample Node.js (server-side) application with bootstrapping
 
-A Node.js app demonstrating LaunchDarkly server-side bootstrapping.
+We've built a simple Node.js app that demonstrates LaunchDarkly server-side bootstrapping.
 
-## Running Locally
+Below, you'll find the build and deploy procedures. To learn more about the Node.js SDK, read [Node.js (server-side) SDK reference](https://docs.launchdarkly.com/sdk/server-side/node-js).
 
-Make sure you have [Node.js](http://nodejs.org/) installed.
+## Build instructions
+
+Make sure you have [Node.js](http://nodejs.org/) installed. Then, clone the repository, set the `LD_SDK_KEY` and `LD_CLIENTSIDE_ID` environment variables, and start your local server. Here's how:
 
 ```sh
 $ git clone git@github.com:launchdarkly/hello-bootstrap.git # or clone your own fork
@@ -17,9 +19,11 @@ $ npm start
 
 Your app should now be running on [localhost:5000](http://localhost:5000/).
 
+Your app should display a JSON representation of all flags in the project and environment associated with your SDK key and Client-side ID, with the values served for both the normal client and the bootstrapped client for the example user.
+
 ## Deploying to Heroku
 
-Make sure you have the [Heroku CLI](https://cli.heroku.com/) installed.
+If you are using Heroku, you can also deploy there. Make sure you have the [Heroku CLI](https://cli.heroku.com/) installed.
 
 ```sh
 $ heroku create
@@ -31,5 +35,3 @@ $ heroku open
 or
 
 [![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
-
-After successful deployment

--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ const LaunchDarkly = require('launchdarkly-node-server-sdk');
 
 var ldClient = LaunchDarkly.init(process.env.LD_SDK_KEY);
 
+// Set up the user properties.
+// This user should appear on your LaunchDarkly users dashboard soon after you run the demo.
+// Normal and bootstrapped flag values for this user should appear in your app.
 var user = {
   key: "bootstrapDemo"
 }


### PR DESCRIPTION
[SC-154156](https://app.shortcut.com/launchdarkly/story/154156/update-node-js-server-side-sdk-hello-app-readme-and-comments-to-standard-design): After receiving some feedback that it'd be helpful if the Hello apps were more standardized, Docs team is working on updating them to [match the spec](https://launchdarkly.atlassian.net/wiki/spaces/ENG/pages/1499562073/SDK+hello+world).

For this app, it’s set up pretty differently since it’s demonstrating different functionality. Some minor readme updates for context & links, and added a comment about the user.

Tested locally, but not with Heroku.