### PR TITLE
chore: update @launchdarkly/node-server-sdk to 9.10.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,28 +18,28 @@
       }
     },
     "node_modules/@launchdarkly/js-sdk-common": {
-      "version": "2.24.1",
-      "resolved": "https://registry.npmjs.org/@launchdarkly/js-sdk-common/-/js-sdk-common-2.24.1.tgz",
-      "integrity": "sha512-rrqZrUwjPWtSkjDNG1qX+BawlyGTx3RFTX4cdHeIR6MOyJR5i9DTzCit8bNBxjI/kGfxZHBepaPlGxoCfJjGFQ==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/js-sdk-common/-/js-sdk-common-2.24.2.tgz",
+      "integrity": "sha512-SuWfR90NZ1ttGxz/2AeavfFXy/sFnFE7PhEBfg4mv0beTF9LeZwVa4XJsVeBe0Zb1PcuUQt7kn4VmFCctQIAzA==",
       "license": "Apache-2.0"
     },
     "node_modules/@launchdarkly/js-server-sdk-common": {
-      "version": "2.18.4",
-      "resolved": "https://registry.npmjs.org/@launchdarkly/js-server-sdk-common/-/js-server-sdk-common-2.18.4.tgz",
-      "integrity": "sha512-N3cYW1MTiXLpUzyIGU2jYo02/ZGeQFxz1diL3utgR+Mkrnb448e34uqt6Mrmv7lHr/IUL5aSgHdiJZc/5+WQAA==",
+      "version": "2.18.5",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/js-server-sdk-common/-/js-server-sdk-common-2.18.5.tgz",
+      "integrity": "sha512-P+KvThDSxzBM1jHmCZuHWaz+B0Wu44GRcpDar7RoT5yFW7HN3l2vQEArYrRHGGDvTE3YWqQxOfVUTRK0pktz1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@launchdarkly/js-sdk-common": "2.24.1",
+        "@launchdarkly/js-sdk-common": "2.24.2",
         "semver": "7.5.4"
       }
     },
     "node_modules/@launchdarkly/node-server-sdk": {
-      "version": "9.10.11",
-      "resolved": "https://registry.npmjs.org/@launchdarkly/node-server-sdk/-/node-server-sdk-9.10.11.tgz",
-      "integrity": "sha512-2YsWGb7S5lxIg9DJpQDkLem69xzfP9PLXnOqZrfZEae5vh68V9nnKG6VpG3gTaHBJg1gDrqcpdJxCwPodI+MSA==",
+      "version": "9.10.12",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/node-server-sdk/-/node-server-sdk-9.10.12.tgz",
+      "integrity": "sha512-jGScTl6n8lKgnuPvRPMOxf2xdE//+asa5mj97bRPa7AOZYmKtjweJMWNlGEGyaFqeOEqkw+VebqMK+qUJuDOug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@launchdarkly/js-server-sdk-common": "2.18.4",
+        "@launchdarkly/js-server-sdk-common": "2.18.5",
         "https-proxy-agent": "^7.0.6",
         "launchdarkly-eventsource": "2.2.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,28 +18,28 @@
       }
     },
     "node_modules/@launchdarkly/js-sdk-common": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@launchdarkly/js-sdk-common/-/js-sdk-common-2.24.0.tgz",
-      "integrity": "sha512-f/xRD8gl/bSOVljat79nAzX0V0QjJ76R54aAbB6PJDWL+7BWBSFMxduaeokzbX53cs3oOVajL8ej/ps7+ojMeQ==",
+      "version": "2.24.1",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/js-sdk-common/-/js-sdk-common-2.24.1.tgz",
+      "integrity": "sha512-rrqZrUwjPWtSkjDNG1qX+BawlyGTx3RFTX4cdHeIR6MOyJR5i9DTzCit8bNBxjI/kGfxZHBepaPlGxoCfJjGFQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@launchdarkly/js-server-sdk-common": {
-      "version": "2.18.3",
-      "resolved": "https://registry.npmjs.org/@launchdarkly/js-server-sdk-common/-/js-server-sdk-common-2.18.3.tgz",
-      "integrity": "sha512-9lf1IRLJSghtDZlUT04KmmJOwRnAUuqXUcn7C2S9jNPDvrsmFJeD9Dpn7PoCUOR5rZgqAEveWdlBw9qjWeY6jw==",
+      "version": "2.18.4",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/js-server-sdk-common/-/js-server-sdk-common-2.18.4.tgz",
+      "integrity": "sha512-N3cYW1MTiXLpUzyIGU2jYo02/ZGeQFxz1diL3utgR+Mkrnb448e34uqt6Mrmv7lHr/IUL5aSgHdiJZc/5+WQAA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@launchdarkly/js-sdk-common": "2.24.0",
+        "@launchdarkly/js-sdk-common": "2.24.1",
         "semver": "7.5.4"
       }
     },
     "node_modules/@launchdarkly/node-server-sdk": {
-      "version": "9.10.10",
-      "resolved": "https://registry.npmjs.org/@launchdarkly/node-server-sdk/-/node-server-sdk-9.10.10.tgz",
-      "integrity": "sha512-qJNVrHbX+FKUhVUl7FWK9ICsL4lJmHBE7vOCkvERFFODRxYrrf8HdiyYDf79aI8JMSOLCKZgcJJKNXAvRJXThg==",
+      "version": "9.10.11",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/node-server-sdk/-/node-server-sdk-9.10.11.tgz",
+      "integrity": "sha512-2YsWGb7S5lxIg9DJpQDkLem69xzfP9PLXnOqZrfZEae5vh68V9nnKG6VpG3gTaHBJg1gDrqcpdJxCwPodI+MSA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@launchdarkly/js-server-sdk-common": "2.18.3",
+        "@launchdarkly/js-server-sdk-common": "2.18.4",
         "https-proxy-agent": "^7.0.6",
         "launchdarkly-eventsource": "2.2.0"
       }


### PR DESCRIPTION
## Summary

Updates `package-lock.json` to resolve the latest patch versions of the LaunchDarkly Node server SDK and its transitive dependencies:

- `@launchdarkly/node-server-sdk`: 9.10.10 → 9.10.12

No changes to `package.json` — the existing `>= 8.0.0` range already covers these versions.

Tested locally: the app starts successfully and both the normal client and bootstrapped client return flag values as expected.

![App running locally](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfaGVBMWRpc2owVHVLd2VVSyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19oZUExZGlzajBUdUt3ZVVLL2I5MGI2Njc3LWI2YTYtNGEwOS1hYjU1LTRhMTQyZDgxYWYxMSIsImlhdCI6MTc3NzMwNzEyMiwiZXhwIjoxNzc3OTExOTIyLCJmaWxlbmFtZSI6ImJvb3RzdHJhcC1zY3JlZW5zaG90LnBuZyJ9.lNRRoqDcSz5elh2hkuXo_8eVd0IGmTcQRQkdb3I0JVU)

## Review & Testing Checklist for Human
- [ ] Run `npm install && npm start` with valid `LD_SDK_KEY` and `LD_CLIENTSIDE_ID` and verify the page loads with flag values for both clients

### Notes
Patch-level lock file bump only; no behavioral changes expected.

Link to Devin session: https://app.devin.ai/sessions/2235e3cbcafe4639bed49daf5aa0d506
Requested by: @kinyoklion