### PR TITLE
chore: update client-side JS SDK from v3 to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,28 +18,28 @@
       }
     },
     "node_modules/@launchdarkly/js-sdk-common": {
-      "version": "2.24.2",
-      "resolved": "https://registry.npmjs.org/@launchdarkly/js-sdk-common/-/js-sdk-common-2.24.2.tgz",
-      "integrity": "sha512-SuWfR90NZ1ttGxz/2AeavfFXy/sFnFE7PhEBfg4mv0beTF9LeZwVa4XJsVeBe0Zb1PcuUQt7kn4VmFCctQIAzA==",
+      "version": "2.24.4",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/js-sdk-common/-/js-sdk-common-2.24.4.tgz",
+      "integrity": "sha512-ikD6MElNa3WPUxXdUIDSBvbig21gfjemEus1Vh0HGcgLThxGglq+EGb0coyc8199+3aqu8c9kpuXEdMBZhOowA==",
       "license": "Apache-2.0"
     },
     "node_modules/@launchdarkly/js-server-sdk-common": {
-      "version": "2.18.5",
-      "resolved": "https://registry.npmjs.org/@launchdarkly/js-server-sdk-common/-/js-server-sdk-common-2.18.5.tgz",
-      "integrity": "sha512-P+KvThDSxzBM1jHmCZuHWaz+B0Wu44GRcpDar7RoT5yFW7HN3l2vQEArYrRHGGDvTE3YWqQxOfVUTRK0pktz1g==",
+      "version": "2.18.7",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/js-server-sdk-common/-/js-server-sdk-common-2.18.7.tgz",
+      "integrity": "sha512-v1vttu8tALIvpm1+Bal2HKtuvpdBBOTVJfAidlqS4PgSO9qyIzMa5R9fTkRFFXUpQh/iLRqPMI2TINubdfd5kg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@launchdarkly/js-sdk-common": "2.24.2",
+        "@launchdarkly/js-sdk-common": "2.24.4",
         "semver": "7.5.4"
       }
     },
     "node_modules/@launchdarkly/node-server-sdk": {
-      "version": "9.10.12",
-      "resolved": "https://registry.npmjs.org/@launchdarkly/node-server-sdk/-/node-server-sdk-9.10.12.tgz",
-      "integrity": "sha512-jGScTl6n8lKgnuPvRPMOxf2xdE//+asa5mj97bRPa7AOZYmKtjweJMWNlGEGyaFqeOEqkw+VebqMK+qUJuDOug==",
+      "version": "9.10.14",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/node-server-sdk/-/node-server-sdk-9.10.14.tgz",
+      "integrity": "sha512-mpgBT0mRBO/2dup7VrKaydyowv7pu3xRqyN7QMsXnOVF5yvC2N2HOBJ7HwBYaNtII32vEa9uQJbX8v2mBfVMaw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@launchdarkly/js-server-sdk-common": "2.18.5",
+        "@launchdarkly/js-server-sdk-common": "2.18.7",
         "https-proxy-agent": "^7.0.6",
         "launchdarkly-eventsource": "2.2.0"
       }
@@ -85,9 +85,9 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -98,7 +98,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -108,10 +108,25 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -470,9 +485,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -907,13 +922,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/views/pages/index.ejs
+++ b/views/pages/index.ejs
@@ -10,17 +10,15 @@
       <li><code>bootstrapped client</code>: <span class="bootstrap">initializing…</span></li>
     </ul>
 
-    <script>
+    <script type="module">
+      import { createClient } from 'https://unpkg.com/@launchdarkly/js-client-sdk@4/dist/index.js';
+
       const context = window.ldContext;
       console.log(`Clients initialized`);
-      const client = LDClient.initialize(window.ldClientsideId, context);
-      const bootstrapClient = LDClient.initialize(window.ldClientsideId, context, {
-        bootstrap: window.ldBootstrap
-      });
+      const client = createClient(window.ldClientsideId, context);
+      const bootstrapClient = createClient(window.ldClientsideId, context);
 
-      client.on('ready', handleUpdateNormalClient);
       client.on('change', handleUpdateNormalClient);
-      bootstrapClient.on('ready', handleUpdateBootstrapClient);
       bootstrapClient.on('change', handleUpdateBootstrapClient);
 
       function handleUpdateNormalClient(){
@@ -33,8 +31,13 @@
       }
       
       function render(selector, targetClient) {
-        document.querySelector(selector).innerHTML = JSON.stringify(targetClient.allFlags(context), null, 2);
+        document.querySelector(selector).innerHTML = JSON.stringify(targetClient.allFlags(), null, 2);
       }
+
+      await Promise.all([
+        client.start().then(() => handleUpdateNormalClient()),
+        bootstrapClient.start({ bootstrap: window.ldBootstrap }).then(() => handleUpdateBootstrapClient())
+      ]);
     </script>
   </body>
 </html>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -1,9 +1,6 @@
 <title>LaunchDarkly server-side bootstrapping demo</title>
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge;chrome=1" />
-<script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.min.js"></script>
-<script src="https://unpkg.com/event-source-polyfill@0.0.12/src/eventsource.min.js"></script>
-<script src="https://unpkg.com/launchdarkly-js-client-sdk@3"></script>
 <script>
     window.ldBootstrap=<%-JSON.stringify(allFlags)%>
     window.ldClientsideId="<%=clientsideId%>"


### PR DESCRIPTION
## Summary
Updates the client-side JavaScript SDK from the old `launchdarkly-js-client-sdk@3` package to `@launchdarkly/js-client-sdk@4`. Also updates the server-side SDK lock file.

Changes:
- Replace `launchdarkly-js-client-sdk@3` CDN script with ES module import from `@launchdarkly/js-client-sdk@4`
- Migrate client-side code from `LDClient.initialize()` to `createClient()` + `start()` API
- Use `start({ bootstrap })` for bootstrapped client initialization
- Remove `es6-promise` and `event-source-polyfill` polyfills (no longer needed with v4)
- Update `package-lock.json` to latest server SDK (9.10.12 → 9.10.14)

## Review & Testing Checklist for Human
- [ ] Verify the bootstrapped client loads flag values instantly while the normal client waits for network
- [ ] Check browser console for any errors or deprecation warnings
- [ ] Test with different flag configurations to ensure both clients update correctly

### Notes
Tested locally — both normal and bootstrapped clients display correct flag values.

![screenshot](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfaGVBMWRpc2owVHVLd2VVSyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19oZUExZGlzajBUdUt3ZVVLLzNiYmZjM2FlLThhY2ItNDVlNC05N2ViLWM4NWIyNWJkYTA1NSIsImlhdCI6MTc3ODQ5MjMwNiwiZXhwIjoxNzc5MDk3MTA2LCJmaWxlbmFtZSI6InNjcmVlbnNob3QucG5nIn0.4jSMuKJf2Miv_D5AkAod64rXi9F-7Rg_f8_DKVT_GpI)

Link to Devin session: https://app.devin.ai/sessions/30e5043dba544d929f3fbd054e5f15dd
Requested by: @kinyoklion