### PR TITLE
chore: update client-side JS SDK to @launchdarkly/js-client-sdk@4

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "A Node.js app demonstrating LaunchDarkly server-side bootstrapping.",
   "engines": {
-    "node": "16.13.1"
+    "node": ">=18"
   },
   "main": "index.js",
   "scripts": {

--- a/views/pages/index.ejs
+++ b/views/pages/index.ejs
@@ -17,9 +17,9 @@
       const client = createClient(window.ldClientsideId, context);
       const bootstrapClient = createClient(window.ldClientsideId, context);
 
-      client.on('ready', handleUpdateNormalClient);
+      client.on('initialized', handleUpdateNormalClient);
       client.on('change', handleUpdateNormalClient);
-      bootstrapClient.on('ready', handleUpdateBootstrapClient);
+      bootstrapClient.on('initialized', handleUpdateBootstrapClient);
       bootstrapClient.on('change', handleUpdateBootstrapClient);
 
       function handleUpdateNormalClient() {

--- a/views/pages/index.ejs
+++ b/views/pages/index.ejs
@@ -10,30 +10,34 @@
       <li><code>bootstrapped client</code>: <span class="bootstrap">initializing…</span></li>
     </ul>
 
-    <script>
+    <script type="module">
+      import { createClient } from 'https://unpkg.com/@launchdarkly/js-client-sdk@4/dist/index.js';
+
       const context = window.ldContext;
-      console.log(`Clients initialized`);
-      const client = LDClient.initialize(window.ldClientsideId, context);
-      const bootstrapClient = LDClient.initialize(window.ldClientsideId, context, {
-        bootstrap: window.ldBootstrap
+      const client = createClient(window.ldClientsideId, context);
+      const bootstrapClient = createClient(window.ldClientsideId, context);
+
+      function render(selector, targetClient) {
+        document.querySelector(selector).innerHTML = JSON.stringify(targetClient.allFlags(), null, 2);
+      }
+
+      client.on('change', () => {
+        console.log('Normal SDK updated');
+        render('.normal', client);
+      });
+      bootstrapClient.on('change', () => {
+        console.log('Bootstrapped SDK updated');
+        render('.bootstrap', bootstrapClient);
       });
 
-      client.on('ready', handleUpdateNormalClient);
-      client.on('change', handleUpdateNormalClient);
-      bootstrapClient.on('ready', handleUpdateBootstrapClient);
-      bootstrapClient.on('change', handleUpdateBootstrapClient);
-
-      function handleUpdateNormalClient(){
-        console.log(`Normal SDK updated`);
+      const normalResult = await client.start();
+      if (normalResult.status === 'complete') {
         render('.normal', client);
       }
-      function handleUpdateBootstrapClient(){
-        console.log(`Bootstrapped SDK updated`);
+
+      const bootstrapResult = await bootstrapClient.start({ bootstrap: window.ldBootstrap });
+      if (bootstrapResult.status === 'complete') {
         render('.bootstrap', bootstrapClient);
-      }
-      
-      function render(selector, targetClient) {
-        document.querySelector(selector).innerHTML = JSON.stringify(targetClient.allFlags(context), null, 2);
       }
     </script>
   </body>

--- a/views/pages/index.ejs
+++ b/views/pages/index.ejs
@@ -35,8 +35,8 @@
         document.querySelector(selector).innerHTML = JSON.stringify(targetClient.allFlags(), null, 2);
       }
 
-      client.start();
-      bootstrapClient.start({ bootstrap: window.ldBootstrap });
+      client.start().catch(console.error);
+      bootstrapClient.start({ bootstrap: window.ldBootstrap }).catch(console.error);
     </script>
   </body>
 </html>

--- a/views/pages/index.ejs
+++ b/views/pages/index.ejs
@@ -30,12 +30,15 @@
         render('.bootstrap', bootstrapClient);
       });
 
-      const normalResult = await client.start();
+      const normalPromise = client.start();
+      const bootstrapPromise = bootstrapClient.start({ bootstrap: window.ldBootstrap });
+
+      const normalResult = await normalPromise;
       if (normalResult.status === 'complete') {
         render('.normal', client);
       }
 
-      const bootstrapResult = await bootstrapClient.start({ bootstrap: window.ldBootstrap });
+      const bootstrapResult = await bootstrapPromise;
       if (bootstrapResult.status === 'complete') {
         render('.bootstrap', bootstrapClient);
       }

--- a/views/pages/index.ejs
+++ b/views/pages/index.ejs
@@ -17,30 +17,26 @@
       const client = createClient(window.ldClientsideId, context);
       const bootstrapClient = createClient(window.ldClientsideId, context);
 
+      client.on('ready', handleUpdateNormalClient);
+      client.on('change', handleUpdateNormalClient);
+      bootstrapClient.on('ready', handleUpdateBootstrapClient);
+      bootstrapClient.on('change', handleUpdateBootstrapClient);
+
+      function handleUpdateNormalClient() {
+        console.log('Normal SDK updated');
+        render('.normal', client);
+      }
+      function handleUpdateBootstrapClient() {
+        console.log('Bootstrapped SDK updated');
+        render('.bootstrap', bootstrapClient);
+      }
+
       function render(selector, targetClient) {
         document.querySelector(selector).innerHTML = JSON.stringify(targetClient.allFlags(), null, 2);
       }
 
-      client.on('change', () => {
-        console.log('Normal SDK updated');
-        render('.normal', client);
-      });
-      bootstrapClient.on('change', () => {
-        console.log('Bootstrapped SDK updated');
-        render('.bootstrap', bootstrapClient);
-      });
-
-      client.start().then((result) => {
-        if (result.status === 'complete') {
-          render('.normal', client);
-        }
-      });
-
-      bootstrapClient.start({ bootstrap: window.ldBootstrap }).then((result) => {
-        if (result.status === 'complete') {
-          render('.bootstrap', bootstrapClient);
-        }
-      });
+      client.start();
+      bootstrapClient.start({ bootstrap: window.ldBootstrap });
     </script>
   </body>
 </html>

--- a/views/pages/index.ejs
+++ b/views/pages/index.ejs
@@ -30,18 +30,17 @@
         render('.bootstrap', bootstrapClient);
       });
 
-      const normalPromise = client.start();
-      const bootstrapPromise = bootstrapClient.start({ bootstrap: window.ldBootstrap });
+      client.start().then((result) => {
+        if (result.status === 'complete') {
+          render('.normal', client);
+        }
+      });
 
-      const normalResult = await normalPromise;
-      if (normalResult.status === 'complete') {
-        render('.normal', client);
-      }
-
-      const bootstrapResult = await bootstrapPromise;
-      if (bootstrapResult.status === 'complete') {
-        render('.bootstrap', bootstrapClient);
-      }
+      bootstrapClient.start({ bootstrap: window.ldBootstrap }).then((result) => {
+        if (result.status === 'complete') {
+          render('.bootstrap', bootstrapClient);
+        }
+      });
     </script>
   </body>
 </html>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -1,9 +1,6 @@
 <title>LaunchDarkly server-side bootstrapping demo</title>
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge;chrome=1" />
-<script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.min.js"></script>
-<script src="https://unpkg.com/event-source-polyfill@0.0.12/src/eventsource.min.js"></script>
-<script src="https://unpkg.com/launchdarkly-js-client-sdk@3"></script>
 <script>
     window.ldBootstrap=<%-JSON.stringify(allFlags)%>
     window.ldClientsideId="<%=clientsideId%>"


### PR DESCRIPTION
## Summary
Update the client-side JavaScript SDK from the legacy `launchdarkly-js-client-sdk@3` to the current `@launchdarkly/js-client-sdk@4`.

Changes:
- Replace `launchdarkly-js-client-sdk@3` CDN script with `@launchdarkly/js-client-sdk@4` ESM import
- Update client-side API from `LDClient.initialize()` to `createClient()` + `start()`
- Move `bootstrap` option from `createClient()` options to `start()` options (new SDK API)
- Start both clients concurrently so the bootstrapped client renders independently (preserving the demo's purpose)
- Remove unnecessary `es6-promise` and `event-source-polyfill` polyfills
- Update Node.js engine requirement from `16.13.1` to `>=18`

Tested locally — both normal and bootstrapped clients display flag values correctly with no console warnings.

![Screenshot of working app](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfaGVBMWRpc2owVHVLd2VVSyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19oZUExZGlzajBUdUt3ZVVLLzdhMGMyNDk5LTE1ZDEtNDM2ZS05YzJiLWZlN2I1MDRjMDg2NiIsImlhdCI6MTc3OTcwMDg0MywiZXhwIjoxNzgwMzA1NjQzLCJmaWxlbmFtZSI6ImhlbGxvLWJvb3RzdHJhcC13b3JraW5nLnBuZyJ9.fXHg-wIBCjWHDqWgQu5EtisoR1AZLVDyNEF9d3SxpNU)

## Review & Testing Checklist for Human
- [ ] Run `npm install && npm start` with valid `LD_SDK_KEY` and `LD_CLIENTSIDE_ID` and verify both normal and bootstrapped clients display flag values
- [ ] Verify the bootstrapped client loads flags instantly (without waiting for the streaming connection)
- [ ] Toggle a flag in the LaunchDarkly dashboard and verify both clients update in real-time

### Notes
The server-side SDK (`@launchdarkly/node-server-sdk >= 8.0.0`) was not changed — it already resolves to the latest version (9.11.0).

Link to Devin session: https://app.devin.ai/sessions/b648d8cd5e0b4a04ba0cbf1dcd1a9886
Requested by: @kinyoklion
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/hello-bootstrap/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->