### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Repository Maintainers
+* @launchdarkly/team-sdk-js


### PR DESCRIPTION
## Summary
Adds a `CODEOWNERS` file assigning `@launchdarkly/team-sdk-js` as the default code owner, consistent with other JS SDK repositories (e.g., `react-client-sdk`, `vue-client-sdk`).

## Review & Testing Checklist for Human
- [ ] Verify `@launchdarkly/team-sdk-js` is the correct team for this repo

### Notes
No functional code changes.

Link to Devin session: https://app.devin.ai/sessions/4cac95adfe7845238bd4f92a5f9ec7bb
Requested by: @kinyoklion